### PR TITLE
expand grpcbox_client:options() type

### DIFF
--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -25,7 +25,8 @@
 -include("grpcbox.hrl").
 
 -type options() :: #{channel => grpcbox_channel:t(),
-                     encoding => grpcbox:encoding()}.
+                     encoding => grpcbox:encoding(),
+                     atom() => any()}.
 
 -type unary_interceptor() :: term().
 -type stream_interceptor() :: term().


### PR DESCRIPTION
grpcbox_client:options() is expanded to pass custom options to interceptor